### PR TITLE
Fix rvm use 2.3 error on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rvm:
   - 2.0.0
   - 2.1
   - 2.2
-  - 2.3
+  - 2.3.0
   - rbx
   - jruby
   - jruby-head


### PR DESCRIPTION
fix rvm use 2.3 error at #185.
but rbx is still errored... :-(
